### PR TITLE
fix: some emails generated too long refresh token

### DIFF
--- a/backend/src/main/java/stud/ntnu/krisefikser/auth/entity/RefreshToken.java
+++ b/backend/src/main/java/stud/ntnu/krisefikser/auth/entity/RefreshToken.java
@@ -35,7 +35,7 @@ public class RefreshToken {
   @UuidGenerator(style = UuidGenerator.Style.RANDOM)
   private UUID id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, columnDefinition = "TEXT")
   private String token;
 
   @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
This pr fixes a critical bug around too long emails not being able to create refresh tokens

## Checklist
<!-- Mark completed items with an [x] -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code in complex areas
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or my feature works
