### PR TITLE
chore(frontend): gitignore local TS emit next to config files

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -36,3 +36,12 @@ coverage
 
 test-results/
 playwright-report/
+
+# Local TS emit next to config sources (do not commit)
+vite.config.js
+vite.config.d.ts
+vitest.config.js
+vitest.config.d.ts
+cypress.config.d.ts
+orval.config.js
+orval.config.d.ts


### PR DESCRIPTION
Ignores \ite.config.js\/\.d.ts\, \itest.config.js\/\.d.ts\, \cypress.config.d.ts\, and \orval.config.js\/\.d.ts\ so local \	sc\ runs do not pollute \git status\.